### PR TITLE
fix: resolve issue #26 - Query - 1Hz output on INT pin not working correctly

### DIFF
--- a/DFRobot_SD3031.cpp
+++ b/DFRobot_SD3031.cpp
@@ -357,7 +357,7 @@ void DFRobot_SD3031::enableFrequency(eFrequency_t fr)
   uint8_t reg2,reg3;
   readReg(SD3031_REG_CTR2, &reg2, 1);
   readReg(SD3031_REG_CTR3, &reg3, 1);
-  reg2 = reg2 | 0x21;
+  reg2 = 0xEF;
   reg3 = reg3 | fr;
   writeReg(SD3031_REG_CTR2, &reg2, 1);
   writeReg(SD3031_REG_CTR3, &reg3, 1);


### PR DESCRIPTION
## Summary
- Auto-generated fix for #26.
- Changes are intentionally kept minimal and focused.
- Tests were not executed in automation; manual review is required.

## Validation
- [ ] Human code review
- [ ] Manual verification